### PR TITLE
Octomap diff

### DIFF
--- a/octomap_server/include/octomap_server/TrackingOctomapServer.h
+++ b/octomap_server/include/octomap_server/TrackingOctomapServer.h
@@ -48,6 +48,7 @@ protected:
   bool listen_changes;
   bool track_changes;
   int min_change_pub;
+  std::string change_id_frame;
   ros::Publisher pubFreeChangeSet;
   ros::Publisher pubChangeSet;
   ros::Subscriber subChangeSet;

--- a/octomap_server/include/octomap_server/TrackingOctomapServer.h
+++ b/octomap_server/include/octomap_server/TrackingOctomapServer.h
@@ -47,6 +47,7 @@ protected:
 
   bool listen_changes;
   bool track_changes;
+  int min_change_pub;
   ros::Publisher pubFreeChangeSet;
   ros::Publisher pubChangeSet;
   ros::Subscriber subChangeSet;

--- a/octomap_server/launch/octomap_tracking_server.launch
+++ b/octomap_server/launch/octomap_tracking_server.launch
@@ -1,6 +1,10 @@
 <launch>
+
+  <arg name="path" default=""/>
+  <arg name="changeIdFrame" default="/talker/changes"/>
+
 	<!-- you can load an exisiting tree with <node ... args="tree.bt"> !-->
-	<node pkg="octomap_server" type="octomap_tracking_server_node" name="octomap_talker" output="screen">
+	<node pkg="octomap_server" type="octomap_tracking_server_node" name="octomap_talker" output="screen" args="$(arg path)">
 		<param name="resolution" value="0.02" />
 		<param name="frame_id" type="string" value="map" />
 		<param name="sensor_model/max_range" value="4.0" />
@@ -8,6 +12,8 @@
 		<param name="track_changes" value="true"/>
 		<param name="listen_changes" value="false"/>
 		<param name="topic_changes" value="/octomap_tracking_server/changeset" />
+    <param name="change_id_frame" value="$(arg changeIdFrame)" />
+    <param name="min_change_pub" value="0" />
 		<!--remap from="cloud_in" to="/rgbdslam/batch_clouds" /-->
 	</node>
 </launch>

--- a/octomap_server/src/TrackingOctomapServer.cpp
+++ b/octomap_server/src/TrackingOctomapServer.cpp
@@ -59,6 +59,7 @@ TrackingOctomapServer::TrackingOctomapServer(const std::string& filename) :
   private_nh.param("topic_changes", changeSetTopic, changeSetTopic);
   private_nh.param("track_changes", track_changes, false);
   private_nh.param("listen_changes", listen_changes, false);
+  private_nh.param("min_change_pub", min_change_pub, 0);
 
   if (track_changes && listen_changes) {
     ROS_WARN("OctoMapServer: It might not be useful to publish changes and at the same time listen to them."
@@ -121,11 +122,8 @@ void TrackingOctomapServer::trackChanges() {
     changedCells.push_back(pnt);
   }
 
-  // TODO : could set a threshold different than 0 here
-  // through ROS param srv
-  //
   // TODO : !!!! rosparam to set up that ptcloud frame
-  if (c != 0)
+  if (c > min_change_pub)
   {
     sensor_msgs::PointCloud2 changed;
     pcl::toROSMsg(changedCells, changed);

--- a/octomap_server/src/TrackingOctomapServer.cpp
+++ b/octomap_server/src/TrackingOctomapServer.cpp
@@ -55,8 +55,10 @@ TrackingOctomapServer::TrackingOctomapServer(const std::string& filename) :
   ros::NodeHandle private_nh("~");
 
   std::string changeSetTopic = "changes";
+  std::string changeIdFrame = "/talker/changes";
 
   private_nh.param("topic_changes", changeSetTopic, changeSetTopic);
+  private_nh.param("change_id_frame", change_id_frame, changeIdFrame);
   private_nh.param("track_changes", track_changes, false);
   private_nh.param("listen_changes", listen_changes, false);
   private_nh.param("min_change_pub", min_change_pub, 0);
@@ -122,12 +124,11 @@ void TrackingOctomapServer::trackChanges() {
     changedCells.push_back(pnt);
   }
 
-  // TODO : !!!! rosparam to set up that ptcloud frame
   if (c > min_change_pub)
   {
     sensor_msgs::PointCloud2 changed;
     pcl::toROSMsg(changedCells, changed);
-    changed.header.frame_id = "map";
+    changed.header.frame_id = change_id_frame;
     changed.header.stamp = ros::Time().now();
     pubChangeSet.publish(changed);
     ROS_DEBUG("[server] sending %d changed entries", (int)changedCells.size());


### PR DESCRIPTION
TrackingOctomapServer publishes centroid of changed nodes rather than their key.

It avoid publishing empty cloud - a parameter defining the minimum number of changed nodes to trigger the publish has been added

The frame_id of the published point cloud can be defined through a ros param

Server launch file has been updated according to above changes.