### PR TITLE
Change iterator in OctomapServer

### DIFF
--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -391,7 +391,7 @@ void OctomapServer::insertScan(const tf::Point& sensorOriginTf, const PCLPointCl
   }
 
   // now mark all occupied cells:
-  for (KeySet::iterator it = occupied_cells.begin(), end=free_cells.end(); it!= end; it++) {
+  for (KeySet::iterator it = occupied_cells.begin(), end=occupied_cells.end(); it!= end; it++) {
     m_octree->updateNode(*it, true);
   }
 


### PR DESCRIPTION
Reading through the source code, I have noticed that the end of the iterator iterating over the occupied_cells was specified by the length of the free_cells KeySet. I think this should be replaced by the occupied_cells length as completed in this commit/PR. Or is there perhaps another underlying reason for this choice?