### PR TITLE
Fixed maxRange bug in OctomapServer.cpp

### DIFF
--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -423,6 +423,7 @@ void OctomapServer::insertScan(const tf::Point& sensorOriginTf, const PCLPointCl
 
         octomap::OcTreeKey endKey;
         if (m_octree->coordToKeyChecked(new_end, endKey)){
+          free_cells.insert(endKey);
           updateMinKey(endKey, m_updateBBXMin);
           updateMaxKey(endKey, m_updateBBXMax);
         } else{


### PR DESCRIPTION
It's possible for a voxel at sensor_model/max_range to be set, but not cleared.
This small change ensures that voxels at max_range get cleared properly.

I made a graphic depicting the problem:
![untitled drawing](https://cloud.githubusercontent.com/assets/3754452/15272157/58be6088-1a21-11e6-92df-646854dcadb8.png)
