### PR TITLE
Forward nodelet NodeHandle to the octomap_server_nodelet

### DIFF
--- a/octomap_server/include/octomap_server/OctomapServer.h
+++ b/octomap_server/include/octomap_server/OctomapServer.h
@@ -88,7 +88,7 @@ public:
   typedef octomap_msgs::GetOctomap OctomapSrv;
   typedef octomap_msgs::BoundingBoxQuery BBXSrv;
 
-  OctomapServer(ros::NodeHandle private_nh_ = ros::NodeHandle("~"));
+  OctomapServer(const ros::NodeHandle &nh_ = ros::NodeHandle(), const ros::NodeHandle &private_nh_ = ros::NodeHandle("~"));
   virtual ~OctomapServer();
   virtual bool octomapBinarySrv(OctomapSrv::Request  &req, OctomapSrv::GetOctomap::Response &res);
   virtual bool octomapFullSrv(OctomapSrv::Request  &req, OctomapSrv::GetOctomap::Response &res);

--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -43,7 +43,7 @@ OctomapServer::OctomapServer(const ros::NodeHandle &nh_, const ros::NodeHandle &
 : m_nh(nh_),
   m_pointCloudSub(NULL),
   m_tfPointCloudSub(NULL),
-  m_reconfigureServer(m_config_mutex),
+  m_reconfigureServer(m_config_mutex, private_nh_),
   m_octree(NULL),
   m_maxRange(-1.0),
   m_worldFrameId("/map"), m_baseFrameId("base_footprint"),

--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -39,8 +39,8 @@ bool is_equal (double a, double b, double epsilon = 1.0e-7)
 
 namespace octomap_server{
 
-OctomapServer::OctomapServer(ros::NodeHandle private_nh_)
-: m_nh(),
+OctomapServer::OctomapServer(const ros::NodeHandle &nh_, const ros::NodeHandle &private_nh_)
+: m_nh(nh_),
   m_pointCloudSub(NULL),
   m_tfPointCloudSub(NULL),
   m_reconfigureServer(m_config_mutex),

--- a/octomap_server/src/octomap_server_node.cpp
+++ b/octomap_server/src/octomap_server_node.cpp
@@ -46,7 +46,8 @@ using namespace octomap_server;
 
 int main(int argc, char** argv){
   ros::init(argc, argv, "octomap_server");
-  const ros::NodeHandle& private_nh = ros::NodeHandle("~");
+  ros::NodeHandle nh;
+  ros::NodeHandle private_nh("~");
   std::string mapFilename(""), mapFilenameParam("");
 
   if (argc > 2 || (argc == 2 && std::string(argv[1]) == "-h")){
@@ -54,7 +55,7 @@ int main(int argc, char** argv){
     exit(-1);
   }
 
-  OctomapServer server;
+  OctomapServer server(nh, private_nh);
   ros::spinOnce();
 
   if (argc == 2){

--- a/octomap_server/src/octomap_server_nodelet.cpp
+++ b/octomap_server/src/octomap_server_nodelet.cpp
@@ -49,8 +49,9 @@ public:
   virtual void onInit()
   {
     NODELET_DEBUG("Initializing octomap server nodelet ...");
+    ros::NodeHandle& nh = this->getNodeHandle();
     ros::NodeHandle& private_nh = this->getPrivateNodeHandle();
-    server_.reset(new OctomapServer(private_nh));
+    server_.reset(new OctomapServer(nh, private_nh));
 
     std::string mapFilename("");
     if (private_nh.getParam("map_file", mapFilename)) {


### PR DESCRIPTION
I discovered the problem that #39 refers to - the node handle is not initialised with a call to `nodelet::getNodeHandle()` and the mappings are wrong.
And it turns out I'm not the first to find this - this commit is cherry-picked from @SafeDroneWare fork.

Fixes #39 