### PR TITLE
update to use non deprecated pluginlib macro

### DIFF
--- a/octomap_server/src/octomap_server_nodelet.cpp
+++ b/octomap_server/src/octomap_server_nodelet.cpp
@@ -65,4 +65,4 @@ private:
 
 } // namespace
 
-PLUGINLIB_DECLARE_CLASS(octomap_server, OctomapServerNodelet, octomap_server::OctomapServerNodelet, nodelet::Nodelet);
+PLUGINLIB_EXPORT_CLASS(octomap_server::OctomapServerNodelet, nodelet::Nodelet)


### PR DESCRIPTION
These macros, deprecated for now 8 years, will be removed in the next ROS release (ROS Melodic)

This change will allow the code to keep compiling on future ROS versions