### PR TITLE
Update maintainer email, add Travis badges, change DEPENDS to OCTOMAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,4 +5,10 @@ ROS stack for mapping with OctoMap, contains the octomap_server package.
 
 The `master` branch tracks the latest (stable) releases. Please send pull requests against the latest development branch, e.g. `indigo-devel`.
 
+Indigo: [![Build Status](https://travis-ci.org/OctoMap/octomap_mapping.svg?branch=indigo-devel)](https://travis-ci.org/OctoMap/octomap_mapping)
+
+Kinetic: [![Build Status](https://travis-ci.org/OctoMap/octomap_mapping.svg?branch=kinetic-devel)](https://travis-ci.org/OctoMap/octomap_mapping)
+
+Melodic: [![Build Status](https://travis-ci.org/OctoMap/octomap_mapping.svg?branch=melodic-devel)](https://travis-ci.org/OctoMap/octomap_mapping)
+
 Imported from SVN, see https://code.google.com/p/alufr-ros-pkg/ for the previous versions.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ The `master` branch tracks the latest (stable) releases. Please send pull reques
 
 Indigo: [![Build Status](https://travis-ci.org/OctoMap/octomap_mapping.svg?branch=indigo-devel)](https://travis-ci.org/OctoMap/octomap_mapping)
 
-Kinetic: [![Build Status](https://travis-ci.org/OctoMap/octomap_mapping.svg?branch=kinetic-devel)](https://travis-ci.org/OctoMap/octomap_mapping)
+Kinetic/Melodic: [![Build Status](https://travis-ci.org/OctoMap/octomap_mapping.svg?branch=kinetic-devel)](https://travis-ci.org/OctoMap/octomap_mapping)
 
-Melodic: [![Build Status](https://travis-ci.org/OctoMap/octomap_mapping.svg?branch=melodic-devel)](https://travis-ci.org/OctoMap/octomap_mapping)
+<!--- Melodic: [![Build Status](https://travis-ci.org/OctoMap/octomap_mapping.svg?branch=melodic-devel)](https://travis-ci.org/OctoMap/octomap_mapping)-->
 
 Imported from SVN, see https://code.google.com/p/alufr-ros-pkg/ for the previous versions.

--- a/octomap_mapping/package.xml
+++ b/octomap_mapping/package.xml
@@ -2,10 +2,10 @@
   <name>octomap_mapping</name>
   <version>0.6.1</version>
   <description>
-    Mapping tools to be used with the <a href="http://octomap.github.io/">OctoMap library</a>, implementing a 3D occupancy grid mapping.
+    Mapping tools to be used with the <a href="https://octomap.github.io/">OctoMap library</a>, implementing a 3D occupancy grid mapping.
   </description>
   <author>Armin Hornung</author>
-  <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>  
   
   <url>http://ros.org/wiki/octomap_mapping</url>

--- a/octomap_server/CMakeLists.txt
+++ b/octomap_server/CMakeLists.txt
@@ -31,14 +31,13 @@ include_directories(
   ${OCTOMAP_INCLUDE_DIRS}
 )
 
-
 generate_dynamic_reconfigure_options(cfg/OctomapServer.cfg)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS ${PACKAGE_DEPENDENCIES}
-  DEPENDS octomap PCL
+  DEPENDS OCTOMAP PCL
 )
 
 set(LINK_LIBS

--- a/octomap_server/package.xml
+++ b/octomap_server/package.xml
@@ -5,7 +5,7 @@
     octomap_server loads a 3D map (as Octree-based OctoMap) and distributes it to other nodes in a compact binary format. It also allows to incrementally build 3D OctoMaps, and provides map saving in the node octomap_saver.
   </description>
   <author>Armin Hornung</author>
-  <maintainer email="armin@hornung.io">Armin Hornung</maintainer>
+  <maintainer email="w.merkt+oss@gmail.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>
   <url>http://www.ros.org/wiki/octomap_server</url>
   <url type="bugtracker">https://github.com/OctoMap/octomap_mapping/issues</url>


### PR DESCRIPTION
- Updates maintainer email such that I will receive future ROS buildfarm messages
- Adds Travis badges (requires Travis to be activated for the repository)
- Changes the dependency from `octomap` to `OCTOMAP` as it otherwise creates warnings on Kinetic/Melodic