### PR TITLE
[CI] Fix builds on Debian Stretch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - ROS_DISTRO="melodic" CATKIN_CONFIG='-DCMAKE_BUILD_TYPE=Debug'
     - ROS_DISTRO="melodic" CATKIN_CONFIG='-DCMAKE_BUILD_TYPE=Release'
     - ROS_DISTRO="melodic" PRERELEASE=true
+    - ROS_DISTRO="melodic" OS_NAME="debian" OS_CODE_NAME="stretch"
 matrix:
   allow_failures:
     - env: ROS_DISTRO="kinetic" PRERELEASE=true

--- a/octomap_server/CMakeLists.txt
+++ b/octomap_server/CMakeLists.txt
@@ -13,13 +13,11 @@ set(PACKAGE_DEPENDENCIES
   octomap_ros
   octomap_msgs
   dynamic_reconfigure
-  nodelet  
+  nodelet
 )
 
 
 find_package(catkin REQUIRED COMPONENTS ${PACKAGE_DEPENDENCIES})
-
-find_package(PCL REQUIRED QUIET COMPONENTS common sample_consensus io segmentation filters)
 
 find_package(octomap REQUIRED)
 add_definitions(-DOCTOMAP_NODEBUGOUT)
@@ -27,7 +25,6 @@ add_definitions(-DOCTOMAP_NODEBUGOUT)
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
-  ${PCL_INCLUDE_DIRS}
   ${OCTOMAP_INCLUDE_DIRS}
 )
 
@@ -37,13 +34,12 @@ catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS ${PACKAGE_DEPENDENCIES}
-  DEPENDS OCTOMAP PCL
+  DEPENDS OCTOMAP
 )
 
 set(LINK_LIBS
   ${OCTOMAP_LIBRARIES}
   ${catkin_LIBRARIES}
-  ${PCL_LIBRARIES}
 )
 
 add_library(${PROJECT_NAME} src/OctomapServer.cpp src/OctomapServerMultilayer.cpp src/TrackingOctomapServer.cpp)


### PR DESCRIPTION
The ROS Melodic builds on Debian Stretch are currently failing due to linking errors with Qt5Widgets, which has been resolved upstream in `pcl_ros`. This is to debug and fix the issue and then push a fix to the buildfarm.