### PR TITLE
Add octomap_server_color library

### DIFF
--- a/octomap_server/CMakeLists.txt
+++ b/octomap_server/CMakeLists.txt
@@ -46,11 +46,16 @@ add_library(${PROJECT_NAME} src/OctomapServer.cpp src/OctomapServerMultilayer.cp
 target_link_libraries(${PROJECT_NAME} ${LINK_LIBS})
 add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_gencfg)
 
+add_library(${PROJECT_NAME}_color src/OctomapServer.cpp src/OctomapServerMultilayer.cpp src/TrackingOctomapServer.cpp)
+target_link_libraries(${PROJECT_NAME}_color ${LINK_LIBS})
+add_dependencies(${PROJECT_NAME}_color ${PROJECT_NAME}_gencfg)
+target_compile_definitions(${PROJECT_NAME}_color PUBLIC COLOR_OCTOMAP_SERVER)
+
 add_executable(octomap_server_node src/octomap_server_node.cpp)
 target_link_libraries(octomap_server_node ${PROJECT_NAME} ${LINK_LIBS})
 
-#add_executable(octomap_color_server_node src/octomap_color_server_node.cpp)
-#target_link_libraries(octomap_color_server_node ${PROJECT_NAME} ${LINK_LIBS})
+add_executable(octomap_color_server_node src/octomap_server_node.cpp)
+target_link_libraries(octomap_color_server_node ${PROJECT_NAME}_color ${LINK_LIBS})
 
 add_executable(octomap_server_static src/octomap_server_static.cpp)
 target_link_libraries(octomap_server_static ${PROJECT_NAME} ${LINK_LIBS})
@@ -69,8 +74,9 @@ add_library(octomap_server_nodelet src/octomap_server_nodelet.cpp)
 target_link_libraries(octomap_server_nodelet ${PROJECT_NAME} ${LINK_LIBS})
 
 # install targets:
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS ${PROJECT_NAME} ${PROJECT_NAME}_color
   octomap_server_node
+  octomap_color_server_node
   octomap_server_static
   octomap_server_multilayer
   octomap_saver

--- a/octomap_server/include/octomap_server/OctomapServer.h
+++ b/octomap_server/include/octomap_server/OctomapServer.h
@@ -66,7 +66,7 @@
 #include <octomap/octomap.h>
 #include <octomap/OcTreeKey.h>
 
-//#define COLOR_OCTOMAP_SERVER // turned off here, turned on identical ColorOctomapServer.h - easier maintenance, only maintain OctomapServer and then copy and paste to ColorOctomapServer and change define. There are prettier ways to do this, but this works for now
+//#define COLOR_OCTOMAP_SERVER // switch color here - easier maintenance, only maintain OctomapServer. Two targets are defined in the cmake, octomap_server_color and octomap_server. One has this defined, and the other doesn't
 
 #ifdef COLOR_OCTOMAP_SERVER
 #include <octomap/ColorOcTree.h>


### PR DESCRIPTION
Currently, it appears that in order to use the color octomap server the user must build it from source and change a #define flag. This creates another target with the same source code but ads the compile definition COLOR_OCTOMAP_SERVER. That way, they can both be built at the same time.