### PR TITLE
Add private node handle to fix nodelet support

### DIFF
--- a/octomap_server/include/octomap_server/OctomapServer.h
+++ b/octomap_server/include/octomap_server/OctomapServer.h
@@ -88,7 +88,7 @@ public:
   typedef octomap_msgs::GetOctomap OctomapSrv;
   typedef octomap_msgs::BoundingBoxQuery BBXSrv;
 
-  OctomapServer(ros::NodeHandle private_nh_ = ros::NodeHandle("~"));
+  OctomapServer(const ros::NodeHandle private_nh_ = ros::NodeHandle("~"), const ros::NodeHandle &nh_ = ros::NodeHandle());
   virtual ~OctomapServer();
   virtual bool octomapBinarySrv(OctomapSrv::Request  &req, OctomapSrv::GetOctomap::Response &res);
   virtual bool octomapFullSrv(OctomapSrv::Request  &req, OctomapSrv::GetOctomap::Response &res);
@@ -199,6 +199,7 @@ protected:
 
   static std_msgs::ColorRGBA heightMapColor(double h);
   ros::NodeHandle m_nh;
+  ros::NodeHandle m_nh_private;
   ros::Publisher  m_markerPub, m_binaryMapPub, m_fullMapPub, m_pointCloudPub, m_collisionObjectPub, m_mapPub, m_cmapPub, m_fmapPub, m_fmarkerPub;
   message_filters::Subscriber<sensor_msgs::PointCloud2>* m_pointCloudSub;
   tf::MessageFilter<sensor_msgs::PointCloud2>* m_tfPointCloudSub;

--- a/octomap_server/src/octomap_server_node.cpp
+++ b/octomap_server/src/octomap_server_node.cpp
@@ -46,7 +46,8 @@ using namespace octomap_server;
 
 int main(int argc, char** argv){
   ros::init(argc, argv, "octomap_server");
-  const ros::NodeHandle& private_nh = ros::NodeHandle("~");
+  const ros::NodeHandle nh;
+  const ros::NodeHandle private_nh("~");
   std::string mapFilename(""), mapFilenameParam("");
 
   if (argc > 2 || (argc == 2 && std::string(argv[1]) == "-h")){
@@ -54,7 +55,7 @@ int main(int argc, char** argv){
     exit(-1);
   }
 
-  OctomapServer server;
+  OctomapServer server(private_nh, nh);
   ros::spinOnce();
 
   if (argc == 2){

--- a/octomap_server/src/octomap_server_nodelet.cpp
+++ b/octomap_server/src/octomap_server_nodelet.cpp
@@ -49,8 +49,9 @@ public:
   virtual void onInit()
   {
     NODELET_DEBUG("Initializing octomap server nodelet ...");
+    ros::NodeHandle& nh = this->getNodeHandle();
     ros::NodeHandle& private_nh = this->getPrivateNodeHandle();
-    server_.reset(new OctomapServer(private_nh));
+    server_.reset(new OctomapServer(private_nh, nh));
 
     std::string mapFilename("");
     if (private_nh.getParam("map_file", mapFilename)) {


### PR DESCRIPTION
- Addresses #39
- Supersedes #42

This PR builds on #42 and swaps the order of parameters for the constructor to maintain backwards compatibility. 