### PR TITLE
fix: throw error when path for saving octomap is invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ ROS stack for mapping with OctoMap, contains the `octomap_server` package.
 The main branch for ROS1 Kinetic, Melodic, and Noetic is `kinetic-devel`.
 
 The main branch for ROS2 Foxy and newer is `ros2`.
+
+### Usage
+
+#### Save octomap
+
+```
+ros2 run octomap_server octomap_saver_node --ros-args -p octomap_path:=(path for saving octomap)
+```
+Note: The extension of octomap path should be `.bt` or `.ot`

--- a/octomap_server/src/octomap_saver.cpp
+++ b/octomap_server/src/octomap_saver.cpp
@@ -56,6 +56,11 @@ OctomapSaver::OctomapSaver(
 
   const bool full = declare_parameter("full", false);
   const auto map_name = declare_parameter("octomap_path", "");
+  if (map_name.length() < 4) {
+    RCLCPP_ERROR_STREAM(get_logger(), "Invalid file name or extension: " << map_name);
+    rclcpp::shutdown();
+    return;
+  }
   const auto srv_name = full ? "octomap_full" : "octomap_binary";
   auto client = create_client<GetOctomap>(srv_name);
 


### PR DESCRIPTION
Closes #103.

- throw error when path for saving octomap is invalid
- add instruction to save octomap