### PR TITLE
Change frame id "/map" to "map" to prevent map Rviz visualization error in ROS Noetic caused by TF

### DIFF
--- a/octomap_server/src/OctomapServer.cpp
+++ b/octomap_server/src/OctomapServer.cpp
@@ -48,7 +48,7 @@ OctomapServer::OctomapServer(const ros::NodeHandle private_nh_, const ros::NodeH
   m_octree(NULL),
   m_maxRange(-1.0),
   m_minRange(-1.0),
-  m_worldFrameId("/map"), m_baseFrameId("base_footprint"),
+  m_worldFrameId("map"), m_baseFrameId("base_footprint"),
   m_useHeightMap(true),
   m_useColoredMap(false),
   m_colorFactor(0.8),

--- a/octomap_server/src/octomap_server_static.cpp
+++ b/octomap_server/src/octomap_server_static.cpp
@@ -44,7 +44,7 @@ using namespace octomap;
 class OctomapServerStatic{
 public:
   OctomapServerStatic(const std::string& filename)
-    : m_octree(NULL), m_worldFrameId("/map")
+    : m_octree(NULL), m_worldFrameId("map")
   {
 
     ros::NodeHandle private_nh("~");


### PR DESCRIPTION
Starting from ROS noetic, rviz does not recognize the symbol "/" anymore. 