### PR TITLE
Switch to the system-provided octomap library.

### DIFF
--- a/octomap_server/package.xml
+++ b/octomap_server/package.xml
@@ -16,10 +16,10 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>geometry_msgs</depend>
+  <depend>liboctomap-dev</depend>
   <depend>libpcl-all-dev</depend>
   <depend>message_filters</depend>
   <depend>nav_msgs</depend>
-  <depend>octomap</depend>
   <depend>octomap_msgs</depend>
   <depend>octomap_ros</depend>
   <depend>pcl_conversions</depend>


### PR DESCRIPTION
This ensures that we don't use the ROS-provided one, which can lead to ABI problems.  We'll eventually remove the ROS-provided one.

This was enabled by https://github.com/ros/rosdistro/pull/41623